### PR TITLE
17 induced hierarchy does not create new ids for hierarchical graph nodes

### DIFF
--- a/src/EdgeType.ts
+++ b/src/EdgeType.ts
@@ -25,20 +25,18 @@ export enum TransformationDirection {
 }
 
 export class EdgeType extends NamedElement {
-    id: string;
     priority: number;
     immediate: boolean;
     transformationDirection: TransformationDirection = TransformationDirection.CONTROLFLOW;
 
-    constructor(id: string, priority: number = 0) {
-        super(id);
-        this.id = id;
+    constructor(name: string, priority: number = 0) {
+        super(name);
         this.priority = priority;
         this.immediate = false;
     }
 
     public clone(): EdgeType {
-        const newType = new EdgeType(this.getId()!, this.priority);
+        const newType = new EdgeType(this.getName(), this.priority);
         newType.setImmediate(this.immediate);
         newType.setTransformationDirection(this.transformationDirection);
         this.cloneAnnotationsTo(newType);
@@ -49,10 +47,6 @@ export class EdgeType extends NamedElement {
         return super.equals(other) &&
             this.getPriority() === other.getPriority() &&
             this.isImmediate() === other.isImmediate();
-    }
-    
-    getId(): string {
-        return this.id!;
     }
     
     public getPriority(): number {

--- a/src/Hashable.ts
+++ b/src/Hashable.ts
@@ -19,12 +19,14 @@ export class Hashable {
     protected static objectCount = 0x100 // ORG 100h;
 
     protected _objectId: string;
+    protected _hashCode: number;
 
     constructor() {
-        this._objectId = this.getHashCode();
+        this._hashCode = this.generateHashCode();
+        this._objectId = `0x${this.hashCode().toString(16).padStart(8, '0')}`;
     }
 
-    hashCode(): number {
+    protected generateHashCode(): number {
         if (!Hashable.objectIdMap.has(this)) {
             Hashable.objectIdMap.set(this, `${++Hashable.objectCount}`);
         }
@@ -36,10 +38,18 @@ export class Hashable {
             h = 31 * h + s.charCodeAt(i);
         }
 
-        return h & 0xFFFFFFFF
+        return h & 0xFFFFFFFF;
+    }
+
+    hashCode(): number {
+        return this._hashCode;
     }
 
     getHashCode(): string {
-        return `0x${this.hashCode().toString(16).padStart(8, '0')}`;
+        return this._objectId;
+    }
+
+    public equals(other: Hashable): boolean {
+        return this.hashCode() === other.hashCode();
     }
 }

--- a/src/IHFactory.ts
+++ b/src/IHFactory.ts
@@ -17,20 +17,22 @@
 import { Annotatable } from "./Annotatable";
 import { Annotation } from "./Annotation";
 import { IHGraph } from "./IHGraph";
+import { NamedElement } from "./NamedElement";
 import { SimpleNodeContent } from "./SimpleNode";
 
 export type AnnotationFactoryType = {[key: string]: any};
 
 export interface SourceNodeInterface {
-    id: string
+    name: string
     content?: SimpleNodeContent
     annotations?: AnnotationFactoryType
 }
 
 export interface EdgeTypeInterface {
-    id: string
+    name: string
     priority?: number
     immediate?: boolean
+    annotations?: AnnotationFactoryType
 }
 
 export interface EdgeInterface {
@@ -47,25 +49,21 @@ export interface IHGraphFactoryInterface {
     annotations?: AnnotationFactoryType;
 }
 
-export class SourceNodeFactoryClass extends Annotatable {
-    id: string = "";
+export class SourceNodeFactoryClass extends NamedElement {
     content: SimpleNodeContent = undefined;
 
-    constructor(id: string, content : SimpleNodeContent) {
-        super();
-        this.id = id;
+    constructor(name: string, content : SimpleNodeContent) {
+        super(name);
         this.content = content;
     }
 }
 
-export class EdgeTypeFactoryClass extends Annotatable {
-    id: string = "";
+export class EdgeTypeFactoryClass extends NamedElement {
     priority: number = 0;
     immediate: boolean = false;
 
-    constructor(id: string, priority : number, immediate : boolean) {
-        super();
-        this.id = id;
+    constructor(name: string, priority : number, immediate : boolean) {
+        super(name);
         this.priority = priority;
         this.immediate = immediate;
     }
@@ -91,17 +89,21 @@ export class FactoryObjectClass extends Annotatable {
 
 export function createIHGraphFromJSONString(json: string) {
     const parsedJSON = JSON.parse(json);
+    return createIHGraphFromObject(parsedJSON);
+}
+
+export function createIHGraphFromObject(object: IHGraphFactoryInterface) {
     const ihGraph = new IHGraph();
 
-    if (parsedJSON.annotations) {
-        for (const [id, data] of Object.entries(parsedJSON.annotations)) {
+    if (object.annotations) {
+        for (const [id, data] of Object.entries(object.annotations)) {
             ihGraph.createAnnotation(id, (data as Annotation<any>)["data"]);
         }
     }
 
     // create nodes
-    for (const node of parsedJSON.nodes) {
-        const newNode = ihGraph.createSimpleNode(node.id);
+    for (const node of object.nodes) {
+        const newNode = ihGraph.createSimpleNode(node.name);
         if (node.content) {
             newNode.setContent(node.content);
         }
@@ -113,8 +115,8 @@ export function createIHGraphFromJSONString(json: string) {
     }
 
     // create edge types
-    for (const edgeType of parsedJSON.edgeTypes) {
-        const edgeTypeObject = ihGraph.createEdgeType(edgeType.id, edgeType.priority);
+    for (const edgeType of object.edgeTypes) {
+        const edgeTypeObject = ihGraph.createEdgeType(edgeType.name, edgeType.priority!);
         if (edgeType.immediate) {
             edgeTypeObject.setImmediate(true);
         }
@@ -126,23 +128,23 @@ export function createIHGraphFromJSONString(json: string) {
     }
 
     // create edges
-    for (const edge of parsedJSON.edges) {
+    for (const edge of object.edges) {
         const sourceNode = ihGraph.getNodeByName(edge.sourceNode);
         
         if (!sourceNode) {
-            throw new Error(`Source node with id ${edge.sourceNode} does not exist.`);
+            throw new Error(`Source node with name ${edge.sourceNode} does not exist.`);
         }
 
         const targetNode = ihGraph.getNodeByName(edge.targetNode);
 
         if (!targetNode) {
-            throw new Error(`Target node with id ${edge.targetNode} does not exist.`);
+            throw new Error(`Target node with name ${edge.targetNode} does not exist.`);
         }
 
-        const edgeType = ihGraph.getEdgeTypeById(edge.edgeType);
+        const edgeType = ihGraph.getEdgeTypeByName(edge.edgeType);
 
         if (!edgeType) {
-            throw new Error(`Edge type with id ${edge.type} does not exist.`);
+            throw new Error(`Edge type with name ${edge.edgeType} does not exist.`);
         }
 
         const edgeObject = ihGraph.createTransformationEdge(edgeType, sourceNode, targetNode);

--- a/src/IHFactory.ts
+++ b/src/IHFactory.ts
@@ -127,13 +127,13 @@ export function createIHGraphFromJSONString(json: string) {
 
     // create edges
     for (const edge of parsedJSON.edges) {
-        const sourceNode = ihGraph.getNodeById(edge.sourceNode);
+        const sourceNode = ihGraph.getNodeByName(edge.sourceNode);
         
         if (!sourceNode) {
             throw new Error(`Source node with id ${edge.sourceNode} does not exist.`);
         }
 
-        const targetNode = ihGraph.getNodeById(edge.targetNode);
+        const targetNode = ihGraph.getNodeByName(edge.targetNode);
 
         if (!targetNode) {
             throw new Error(`Target node with id ${edge.targetNode} does not exist.`);

--- a/src/IHGraph.ts
+++ b/src/IHGraph.ts
@@ -1218,7 +1218,7 @@ export class IHGraph extends NamedElement implements EdgeReceiver, KicoCloneable
      * Mainly used in internal operations and debugging.
      * @returns true if everything is consistent.
      */
-    public consistency(): boolean {
+    public consistency(idCacheNodes: Set<string> = new Set<string>(), idCacheTypes: Set<string> = new Set<string>()): boolean {
         const nodes = this.getNodes();
         const edges = this.getAllEdges();
         const edgeTypes = this.getEdgeTypes();
@@ -1240,6 +1240,10 @@ export class IHGraph extends NamedElement implements EdgeReceiver, KicoCloneable
                     throw new ConsistencyError(`An incoming edge of the node ${node.getIdHashCode()} is not included in the graph!`)
                 }
             }
+            if (idCacheNodes.has(node.getId())) {
+                throw new ConsistencyError(`The node id ${node.getIdHashCode()} is not unique!`)
+            }
+            idCacheNodes.add(node.getId());
         }
 
         for (const edge of edges) {
@@ -1264,6 +1268,16 @@ export class IHGraph extends NamedElement implements EdgeReceiver, KicoCloneable
         for (const edgeType of edgeTypes) {
             if (!edges.some((edge) => edge.getType() === edgeType)) {
                 throw new ConsistencyError(`The edge type ${edgeType.getIdHashCode()} is not used by any edge!`)
+            }
+            if (idCacheTypes.has(edgeType.getId())) {
+                throw new ConsistencyError(`The edge type id ${edgeType.getIdHashCode()} is not unique!`)
+            }
+            idCacheTypes.add(edgeType.getId());
+        }
+
+        for (const node of nodes.filter((val) => val instanceof IHGraph)) {
+            if (!(node as IHGraph).consistency(idCacheNodes, idCacheTypes)) {
+                return false;
             }
         }
  

--- a/src/NamedElement.ts
+++ b/src/NamedElement.ts
@@ -55,6 +55,7 @@ export class NamedElement extends Annotatable {
     public cloneTo(target: NamedElement): void {
         super.cloneTo(target);
         target.id = this.id;
+        target.calculateUID();
     }
 
     public equals(other: NamedElement): boolean {

--- a/src/NamedElement.ts
+++ b/src/NamedElement.ts
@@ -17,11 +17,19 @@
 import { Annotatable } from "./Annotatable";
 
 export class NamedElement extends Annotatable {
-    protected id: string;
+    protected id: string = "";
     protected _uid: string = "";
 
     constructor(id: string = "") {
         super();
+        this.setId(id);
+    }
+
+    getId(): string {
+        return this.id;
+    }
+    
+    setId(id: string): void {
         if (id == "") {
             this.id = "id" + this.hashCode();
         } else {
@@ -30,12 +38,8 @@ export class NamedElement extends Annotatable {
         this.calculateUID();
     }
 
-    getId(): string {
-        return this.id;
-    }
-    
-    setId(id: string): void {
-        this.id = id;
+    protected clearId(): void {
+        this.id = "";
         this.calculateUID();
     }
     

--- a/src/NamedElement.ts
+++ b/src/NamedElement.ts
@@ -17,34 +17,34 @@
 import { Annotatable } from "./Annotatable";
 
 export class NamedElement extends Annotatable {
-    protected id: string = "";
+    protected name: string = "";
     protected _uid: string = "";
 
-    constructor(id: string = "") {
+    constructor(name: string = "") {
         super();
-        this.setId(id);
+        this.setName(name);
     }
 
-    getId(): string {
-        return this.id;
+    getName(): string {
+        return this.name;
     }
     
-    setId(id: string): void {
-        if (id == "") {
-            this.id = "id" + this.hashCode();
+    setName(name: string = ""): void {
+        if (name == "") {
+            this.name = "id" + this.hashCode();
         } else {
-            this.id = id;
+            this.name = name;
         }
         this.calculateUID();
     }
 
     protected clearId(): void {
-        this.id = "";
+        this.name = "";
         this.calculateUID();
     }
     
     protected calculateUID(): string {
-        this._uid = `${this.getId()} (${this.getHashCode()})`
+        this._uid = `${this.getName()} (${this.getHashCode()})`
         return this._uid;
     }
     
@@ -54,15 +54,11 @@ export class NamedElement extends Annotatable {
 
     public cloneTo(target: NamedElement): void {
         super.cloneTo(target);
-        target.id = this.id;
+        target.name = this.name;
         target.calculateUID();
-    }
-
-    public equals(other: NamedElement): boolean {
-        return this.getId() === other.getId();
     }
 }
 
-export function getIds(elements: NamedElement[]): string[] {
-    return elements.map((val) => val.getId()!).filter((val) => val != undefined) as string[];
+export function getNames(elements: NamedElement[]): string[] {
+    return elements.map((val) => val.getName()!).filter((val) => val != undefined) as string[];
 }

--- a/src/SimpleNode.ts
+++ b/src/SimpleNode.ts
@@ -30,20 +30,18 @@ export type SimpleNodeContent = undefined | string;
 
 export class SimpleNode extends NamedElement implements EdgeReceiver {
     protected parent : IHGraph;
-    protected id : string;
     protected content : SimpleNodeContent = undefined;
     protected status : SimpleNodeStatus = SimpleNodeStatus.UNDEFINED;
     protected incomingEdges: TransformationEdge[] = [];
     protected outgoingEdges: TransformationEdge[] = [];
 
-    constructor(parent: IHGraph, id : string = "") {
-        super(id);
+    constructor(parent: IHGraph, name : string = "") {
+        super(name);
         this.parent = parent;
-        this.id = id;
     }
 
     public clone(parent: IHGraph | null = null, edgeMapping: Map<TransformationEdge, TransformationEdge> | undefined = undefined): SimpleNode {    
-        const clone = new SimpleNode(parent ? parent : this.parent, this.id);
+        const clone = new SimpleNode(parent ? parent : this.parent, this.getName());
         for (const outgoingEdge of this.outgoingEdges) {
             const edgeClone = outgoingEdge.clone(clone);
             if (edgeMapping !== undefined) {
@@ -63,10 +61,6 @@ export class SimpleNode extends NamedElement implements EdgeReceiver {
 
     public setParent(parent: IHGraph): void {
         this.parent = parent;
-    }
-
-    public getId(): string {
-        return this.id;
     }
 
     public getContent(): SimpleNodeContent {

--- a/src/TransformationConfiguration.ts
+++ b/src/TransformationConfiguration.ts
@@ -35,7 +35,7 @@ export class TransformationConfiguration extends Map<EdgeType, typeof Transforma
 
     public get(edgeType: EdgeType): typeof TransformationProcessor | undefined {
         for (const [key, value] of this.entries()) {
-            if (key.getId() === edgeType.getId()) {
+            if (key.getName() === edgeType.getName()) {
                 return value;
             }
         }

--- a/src/examples/graphs/SCCharts.ts
+++ b/src/examples/graphs/SCCharts.ts
@@ -4,7 +4,7 @@ export function SCCharts(): IHGraphFactoryInterface {
     return {        
         nodes: [
             {
-                id: "Abro",
+                name: "Abro",
                 content: `
 scchart ABRO {
     input bool A, B, R
@@ -36,13 +36,13 @@ scchart ABRO {
 }`
             },
             {
-                id: "Diagram",
+                name: "Diagram",
                 content: ""
             }
         ],
         edgeTypes: [
             {
-                id: "Diagram",
+                name: "Diagram",
                 priority: 0,
                 immediate: true
             }

--- a/src/examples/graphs/Sequence.ts
+++ b/src/examples/graphs/Sequence.ts
@@ -4,18 +4,18 @@ export function Sequence(): IHGraphFactoryInterface {
     return {
         nodes: [
             {
-                id: "Defines"
+                name: "Defines"
             },
             {
-                id: "Setup"
+                name: "Setup"
             },
             {
-                id: "Loop"
+                name: "Loop"
             }
         ],
         edgeTypes: [
             {
-                id: "Sequence",
+                name: "Sequence",
                 priority: 1
             }
         ],

--- a/src/examples/graphs/SequenceExecute.ts
+++ b/src/examples/graphs/SequenceExecute.ts
@@ -4,25 +4,25 @@ export function SequenceExecute(): IHGraphFactoryInterface {
     return {        
         nodes: [
         {
-            id: "Define",
+            name: "Define",
             content: "var x = 1;"
         },
         {
-            id: "Add",
+            name: "Add",
             content: "x + 2"
         },
         {
-            id: "Result",
+            name: "Result",
             content: ""
         }
         ],
         edgeTypes: [
             {
-                id: "Sequence",
+                name: "Sequence",
                 priority: 8
             },
             {
-                id: "Execute",
+                name: "Execute",
                 priority: 2
             }
         ],

--- a/src/examples/graphs/SequenceExecuteNothing.ts
+++ b/src/examples/graphs/SequenceExecuteNothing.ts
@@ -4,33 +4,33 @@ export function SequenceExecuteNothing(): IHGraphFactoryInterface {
     return {        
         nodes: [
         {
-            id: "Define",
+            name: "Define",
             content: "var x = 1;"
         },
         {
-            id: "Add",
+            name: "Add",
             content: "x + 2"
         },
         {
-            id: "Result",
+            name: "Result",
             content: ""
         },
         {
-            id: "Nothing",
+            name: "Nothing",
             content: ""
         }
         ],
         edgeTypes: [
             {
-                id: "Sequence",
+                name: "Sequence",
                 priority: 8
             },
             {
-                id: "Execute",
+                name: "Execute",
                 priority: 2
             },
             {
-                id: "Nothing",
+                name: "Nothing",
                 priority: 0
             }
         ],

--- a/src/examples/graphs/WYTIWYGSum.ts
+++ b/src/examples/graphs/WYTIWYGSum.ts
@@ -4,7 +4,7 @@ export function WYTIWYGSum(): IHGraphFactoryInterface {
     return {        
         nodes: [
             {
-                id: "Function",
+                name: "Function",
                 content: 
 `
 function sum(n: number):number {
@@ -17,21 +17,21 @@ function sum(n: number):number {
 }`
             },
             {
-                id: "Test 1",
+                name: "Test 1",
                 content: "sum(3) == 6"
             },
             {
-                id: "Test 2",
+                name: "Test 2",
                 content: "sum(1)"
             },
             {
-                id: "Test 3",
+                name: "Test 3",
                 content: "sum(-1) == 0"
             }
         ],
         edgeTypes: [
             {
-                id: "wytiwyg",
+                name: "wytiwyg",
                 priority: 0,
                 immediate: true
             }

--- a/src/examples/graphs/WYTIWYGSumExecute.ts
+++ b/src/examples/graphs/WYTIWYGSumExecute.ts
@@ -4,7 +4,7 @@ export function WYTIWYGSumExecute(): IHGraphFactoryInterface {
     return {        
         nodes: [
             {
-                id: "Function",
+                name: "Function",
                 content:
 `function sum(n) {
     if (n > 0) {
@@ -15,42 +15,42 @@ export function WYTIWYGSumExecute(): IHGraphFactoryInterface {
 }`
             },
             {
-                id: "Test 1",
+                name: "Test 1",
                 content: "sum(3) == 6"
             },
             {
-                id: "Test 2",
+                name: "Test 2",
                 content: "sum(1)"
             },
             {
-                id: "Test 3",
+                name: "Test 3",
                 content: "sum(-1) == -1"
             },
             {
-                id: "Usage",
+                name: "Usage",
                 content: 
 `
 sum(3) + sun(1);
 `                
             },
             {
-                id: "Result",
+                name: "Result",
                 content: ""
             }
         ],
         edgeTypes: [
             {
-                id: "test",
+                name: "test",
                 priority: 0,
                 immediate: true
             },
             {
-                id: "sequence",
+                name: "sequence",
                 priority: 2,
                 immediate: false
             },
             {
-                id: "execute",
+                name: "execute",
                 priority: 1,
                 immediate: false
             }

--- a/tests/graph/IHGraph.01.nodes.test.ts
+++ b/tests/graph/IHGraph.01.nodes.test.ts
@@ -34,8 +34,8 @@ test("createTHGraphSimple", () => {
 test("checkTHGraphSimpleNodeById", () => {
     const thGraph = testGraphSimple();
 
-    expect(thGraph.getNodeById("Node1")).toBe(thGraph.getNodes()[0]);
-    expect(thGraph.getNodeById("Node2")).toBe(thGraph.getNodes()[1]);
+    expect(thGraph.getNodeByName("Node1")).toBe(thGraph.getNodes()[0]);
+    expect(thGraph.getNodeByName("Node2")).toBe(thGraph.getNodes()[1]);
 });
 
 test("checkTHGraphSimpleNodeByIdOrder", () => {
@@ -44,16 +44,16 @@ test("checkTHGraphSimpleNodeByIdOrder", () => {
     thGraph.createSimpleNode("Node1");
     thGraph.createSimpleNode("Node1");
 
-    expect(thGraph.getNodeById("Node1")).toBe(thGraph.getNodes()[0]);
-    expect(thGraph.getNodeById("Node1")).not.toBe(thGraph.getNodes()[1]);
-    expect(thGraph.getNodeById("Node1")).not.toBe(thGraph.getNodes()[2]);
+    expect(thGraph.getNodeByName("Node1")).toBe(thGraph.getNodes()[0]);
+    expect(thGraph.getNodeByName("Node1")).not.toBe(thGraph.getNodes()[1]);
+    expect(thGraph.getNodeByName("Node1")).not.toBe(thGraph.getNodes()[2]);
 });
 
 test("checkTHGraphSimplePriority", () => {
     const thGraph = testGraphSimple();
 
-    const node1 = thGraph.getNodeById("Node1");
-    const node2 = thGraph.getNodeById("Node2");
+    const node1 = thGraph.getNodeByName("Node1");
+    const node2 = thGraph.getNodeByName("Node2");
     const type2 = thGraph.createEdgeType("Type2", 2);
     const type32 = thGraph.createEdgeType("Type3", 32);
     expect(node1).toBeDefined();
@@ -70,7 +70,7 @@ test("checkSourceNodes", () => {
     const sourceNodes = graph.getSourceNodes2();
  
     expect(sourceNodes.length).toBe(1);
-    expect(sourceNodes).toContain(graph.getNodeById("Define"));
+    expect(sourceNodes).toContain(graph.getNodeByName("Define"));
 });
 
 test("checkSinkNodes", () => {
@@ -79,14 +79,14 @@ test("checkSinkNodes", () => {
     const sinkNodes = graph.getSinkNodes();
  
     expect(sinkNodes.length).toBe(2);
-    expect(sinkNodes).toContain(graph.getNodeById("Result"));
-    expect(sinkNodes).toContain(graph.getNodeById("Nothing"));
+    expect(sinkNodes).toContain(graph.getNodeByName("Result"));
+    expect(sinkNodes).toContain(graph.getNodeByName("Nothing"));
 });
 
 test("checkNodesContentString", () => {
     const graph = testGraphSequenceExecuteNothing();
 
-    const addNode = graph.getNodeById("Add");
+    const addNode = graph.getNodeByName("Add");
 
     expect(addNode).toBeDefined();
     expect(addNode).toBeInstanceOf(SimpleNode);
@@ -99,7 +99,7 @@ test("checkNodesContentString", () => {
 test("checkNodesContentStringUndefined", () => {
     const graph = testGraphSequenceExecuteNothing();
 
-    const nothingNode = graph.getNodeById("Nothing") as SimpleNode;
+    const nothingNode = graph.getNodeByName("Nothing") as SimpleNode;
 
     expect(nothingNode).toBeDefined();
 

--- a/tests/graph/IHGraph.02.edges.test.ts
+++ b/tests/graph/IHGraph.02.edges.test.ts
@@ -49,7 +49,7 @@ test("getEdges", () => {
 test("getEdgesAfterRemoveNode", () => {
     const graph = testGraphSequenceExecuteNothing();
 
-    graph.removeNodeById("Add")
+    graph.removeNodeByName("Add")
 
     expect(graph.getAllEdges().length).toBe(0);
 });

--- a/tests/graph/IHGraph.09.clone.test.ts
+++ b/tests/graph/IHGraph.09.clone.test.ts
@@ -55,8 +55,8 @@ test("checkTHGraphSimpleCloneComplete", () => {
     // when
     const clone = thGraph.clone();
 
-    const cloneNode1 = clone.getNodeById("Node1");
-    const cloneNode2 = clone.getNodeById("Node2");
+    const cloneNode1 = clone.getNodeByName("Node1");
+    const cloneNode2 = clone.getNodeByName("Node2");
     
     // then
     expect(cloneNode1).toBeDefined();

--- a/tests/graph/IHGraph.23.cliques-retrieve.test.ts
+++ b/tests/graph/IHGraph.23.cliques-retrieve.test.ts
@@ -44,7 +44,7 @@ function testGraphClique2(): IHGraph {
 test("getClique", () => {
     const graph = testGraphClique();
 
-    const node1 = graph.getNodeById("Node1");
+    const node1 = graph.getNodeByName("Node1");
     const type1 = graph.getEdgeTypeById("Type1");
 
     expect(node1).toBeDefined();
@@ -57,8 +57,8 @@ test("getClique", () => {
     expect(clique!.getDeepEdges().length).toBe(1);
     expect(clique!.getEdgeTypes().length).toBe(1);
 
-    const node2 = graph.getNodeById("Node2");
-    const node3 = graph.getNodeById("Node3");
+    const node2 = graph.getNodeByName("Node2");
+    const node3 = graph.getNodeByName("Node3");
     const type2 = graph.getEdgeTypeById("Type2");
  
     expect(node2).toBeDefined();
@@ -73,15 +73,15 @@ test("getClique", () => {
     expect(clique2!.getEdgeTypes().length).toBe(1);  
     
     expect(clique).not.toBe(clique2);
-    expect(clique2.getNodeById("Node2")).toBeDefined();
-    expect(clique2.getNodeById("Node3")).toBeDefined();
+    expect(clique2.getNodeByName("Node2")).toBeDefined();
+    expect(clique2.getNodeByName("Node3")).toBeDefined();
 })
 
 test("getNextClique", () => {
     const graph = testGraphClique();
 
-    const node2 = graph.getNodeById("Node2");
-    const node3 = graph.getNodeById("Node3");
+    const node2 = graph.getNodeByName("Node2");
+    const node3 = graph.getNodeByName("Node3");
     const type2 = graph.getEdgeTypeById("Type2");
  
     expect(node2).toBeDefined();
@@ -95,8 +95,8 @@ test("getNextClique", () => {
     expect(clique.getDeepEdges().length).toBe(1);
     expect(clique.getEdgeTypes().length).toBe(1);  
     
-    expect(clique.getNodeById("Node2")).toBeDefined();
-    expect(clique.getNodeById("Node3")).toBeDefined();
+    expect(clique.getNodeByName("Node2")).toBeDefined();
+    expect(clique.getNodeByName("Node3")).toBeDefined();
 });
 
 test("equalsClique", () => {

--- a/tests/graph/IHGraph.23.cliques-retrieve.test.ts
+++ b/tests/graph/IHGraph.23.cliques-retrieve.test.ts
@@ -45,7 +45,7 @@ test("getClique", () => {
     const graph = testGraphClique();
 
     const node1 = graph.getNodeByName("Node1");
-    const type1 = graph.getEdgeTypeById("Type1");
+    const type1 = graph.getEdgeTypeByName("Type1");
 
     expect(node1).toBeDefined();
     expect(type1).toBeDefined();
@@ -59,7 +59,7 @@ test("getClique", () => {
 
     const node2 = graph.getNodeByName("Node2");
     const node3 = graph.getNodeByName("Node3");
-    const type2 = graph.getEdgeTypeById("Type2");
+    const type2 = graph.getEdgeTypeByName("Type2");
  
     expect(node2).toBeDefined();
     expect(node3).toBeDefined();
@@ -82,7 +82,7 @@ test("getNextClique", () => {
 
     const node2 = graph.getNodeByName("Node2");
     const node3 = graph.getNodeByName("Node3");
-    const type2 = graph.getEdgeTypeById("Type2");
+    const type2 = graph.getEdgeTypeByName("Type2");
  
     expect(node2).toBeDefined();
     expect(node3).toBeDefined();

--- a/tests/graph/IHGraph.24.cliques-modify.test.ts
+++ b/tests/graph/IHGraph.24.cliques-modify.test.ts
@@ -64,10 +64,10 @@ test("removeClique", () => {
     const graph = testGraphClique();
 
     const node1 = graph.getNodeByName("Node1");
-    const type1 = graph.getEdgeTypeById("Type1");
+    const type1 = graph.getEdgeTypeByName("Type1");
     const node2 = graph.getNodeByName("Node2");
     const node3 = graph.getNodeByName("Node3");
-    const type2 = graph.getEdgeTypeById("Type2");
+    const type2 = graph.getEdgeTypeByName("Type2");
 
     expect(node1).toBeDefined();
     expect(node2).toBeDefined();
@@ -107,15 +107,15 @@ test("addClique", () => {
     expect(graph.getDeepEdges().length).toBe(3);
     expect(graph.getEdgeTypes().length).toBe(3);
 
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node1");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node2");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node3");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node4");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node5");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node1");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node2");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node3");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node4");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node5");
 
-    expect(graph.getEdgeTypes().map(type => type.getId())).toContain("Type1");
-    expect(graph.getEdgeTypes().map(type => type.getId())).toContain("Type2");
-    expect(graph.getEdgeTypes().map(type => type.getId())).toContain("Type3");
+    expect(graph.getEdgeTypes().map(type => type.getName())).toContain("Type1");
+    expect(graph.getEdgeTypes().map(type => type.getName())).toContain("Type2");
+    expect(graph.getEdgeTypes().map(type => type.getName())).toContain("Type3");
 });
 
 test("addClique2", () => {
@@ -128,14 +128,14 @@ test("addClique2", () => {
     expect(graph.getDeepEdges().length).toBe(3);
     expect(graph.getEdgeTypes().length).toBe(2);
 
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node1");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node2");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node3");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node6");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node7");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node1");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node2");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node3");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node6");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node7");
 
-    expect(graph.getEdgeTypes().map(type => type.getId())).toContain("Type1");
-    expect(graph.getEdgeTypes().map(type => type.getId())).toContain("Type2");
+    expect(graph.getEdgeTypes().map(type => type.getName())).toContain("Type1");
+    expect(graph.getEdgeTypes().map(type => type.getName())).toContain("Type2");
 });
 
 test("replaceClique", () => {
@@ -152,8 +152,8 @@ test("replaceClique", () => {
     expect(graph.getDeepNodes().length).toBe(2);
     expect(graph.getDeepEdges().length).toBe(1);
 
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node1");
-    expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node8");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node1");
+    expect(graph.getSimpleNodes().map(node => node.getName())).toContain("Node8");
 
     expect(graph.getSimpleNodeEdges()[0].getSourceNode().getName()).toBe("Node1");
     expect(graph.getSimpleNodeEdges()[0].getTargetNode().getName()).toBe("Node8");

--- a/tests/graph/IHGraph.24.cliques-modify.test.ts
+++ b/tests/graph/IHGraph.24.cliques-modify.test.ts
@@ -63,10 +63,10 @@ function testGraphClique4(): IHGraph {
 test("removeClique", () => {
     const graph = testGraphClique();
 
-    const node1 = graph.getNodeById("Node1");
+    const node1 = graph.getNodeByName("Node1");
     const type1 = graph.getEdgeTypeById("Type1");
-    const node2 = graph.getNodeById("Node2");
-    const node3 = graph.getNodeById("Node3");
+    const node2 = graph.getNodeByName("Node2");
+    const node3 = graph.getNodeByName("Node3");
     const type2 = graph.getEdgeTypeById("Type2");
 
     expect(node1).toBeDefined();
@@ -155,6 +155,6 @@ test("replaceClique", () => {
     expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node1");
     expect(graph.getSimpleNodes().map(node => node.getId())).toContain("Node8");
 
-    expect(graph.getSimpleNodeEdges()[0].getSourceNode().getId()).toBe("Node1");
-    expect(graph.getSimpleNodeEdges()[0].getTargetNode().getId()).toBe("Node8");
+    expect(graph.getSimpleNodeEdges()[0].getSourceNode().getName()).toBe("Node1");
+    expect(graph.getSimpleNodeEdges()[0].getTargetNode().getName()).toBe("Node8");
 });

--- a/tests/graph/IHGraph.25.immediate-cliques.test.ts
+++ b/tests/graph/IHGraph.25.immediate-cliques.test.ts
@@ -40,13 +40,13 @@ test("getImmediateCliqueMixed", () => {
 
     expect(immediateClique).toBeDefined();
     expect(immediateClique.length).toBe(1);
-    expect(immediateClique[0].getAllEdges()[0].getType().id).toBe("Diagram");
+    expect(immediateClique[0].getAllEdges()[0].getType().getName()).toBe("Diagram");
 
     const nextClique = graph.getNextClique();
 
     expect(nextClique).toBeDefined();
     expect(nextClique.getNodes().length).toBe(2);
-    expect(nextClique.getAllEdges()[0].getType().id).toBe("SCCharts");
+    expect(nextClique.getAllEdges()[0].getType().getName()).toBe("SCCharts");
 })
 
 test("getImmediateCliqueMultipleEdges", () => {

--- a/tests/graph/IHGraph.26.clique-id.test.ts
+++ b/tests/graph/IHGraph.26.clique-id.test.ts
@@ -27,5 +27,5 @@ test("cliqueReplacementWithCorrectIds", () => {
 
     graph.replaceClique(immediateClique, immediateClique);
 
-    expect(graph.getNodeById("Usage")?.getIncomingEdges()[0].getSourceNode().getId()).toBe("Function");
+    expect(graph.getNodeByName("Usage")?.getIncomingEdges()[0].getSourceNode().getName()).toBe("Function");
 })

--- a/tests/graph/IHGraph.30.induced-hierarchy.test.ts
+++ b/tests/graph/IHGraph.30.induced-hierarchy.test.ts
@@ -36,9 +36,9 @@ test("inducedHierarchyDepth1", () => {
 
     expect(graphNodeSourceNodes.length).toBe(2);
 
-    const defineNode = graphNodeSourceNodes.find(node => node.getId() === "Define");
-    const addNode = graphNodeSourceNodes.find(node => node.getId() === "Add");
-    const resultNode = sourceNodes.find(node => node.getId() === "Result");
+    const defineNode = graphNodeSourceNodes.find(node => node.getName() === "Define");
+    const addNode = graphNodeSourceNodes.find(node => node.getName() === "Add");
+    const resultNode = sourceNodes.find(node => node.getName() === "Result");
 
     expect(defineNode).toBeDefined();
     expect(addNode).toBeDefined();

--- a/tests/graph/IHGraph.30.induced-hierarchy.test.ts
+++ b/tests/graph/IHGraph.30.induced-hierarchy.test.ts
@@ -70,10 +70,55 @@ test("inducedHierarchyDepth2", () => {
 
     expect(nestedGraphNodes.length).toBe(1);
 
-    const defineNode = inducedHierarchyGraph.getNodeById("Define");
-    const addNode = inducedHierarchyGraph.getNodeById("Add");
-    const resultNode = inducedHierarchyGraph.getNodeById("Result");
-    const nothingNode = inducedHierarchyGraph.getNodeById("Nothing");
+    const defineNode = inducedHierarchyGraph.getNodeByName("Define");
+    const addNode = inducedHierarchyGraph.getNodeByName("Add");
+    const resultNode = inducedHierarchyGraph.getNodeByName("Result");
+    const nothingNode = inducedHierarchyGraph.getNodeByName("Nothing");
+
+    expect(defineNode).toBeDefined();
+    expect(addNode).toBeDefined();
+    expect(resultNode).toBeDefined();
+    expect(nothingNode).toBeDefined();
+
+    expect(defineNode?.getParent()).toBe(nestedGraphNodes[0]);
+    expect(addNode?.getParent()).toBe(nestedGraphNodes[0]);
+    expect(resultNode?.getParent()).toBe(graphNodes[0]);
+    expect(nothingNode?.getParent()).toBe(inducedHierarchyGraph);
+
+    expect(defineNode?.getOutgoingEdges().length).toBe(1);
+    expect(defineNode?.getOutgoingEdges()[0].getTargetNode()).toBe(addNode);
+    expect(addNode?.getOutgoingEdges().length).toBe(0);
+    expect(nestedGraphNodes[0].getOutgoingEdges().length).toBe(1);
+    expect(nestedGraphNodes[0].getOutgoingEdges()[0].getTargetNode()).toBe(resultNode);
+    expect(graphNodes[0].getOutgoingEdges().length).toBe(1);
+    expect(graphNodes[0].getOutgoingEdges()[0].getTargetNode()).toBe(nothingNode);
+    expect(inducedHierarchyGraph.getAllEdges().length).toBe(1);
+})
+
+test("inducedHierarchyDepth3IdClone", () => {
+    const graph = testGraphSequenceExecuteNothing().clone().clone();
+
+    expect(graph).toBeDefined();
+
+    const inducedHierarchyGraph = graph.getInducedHierarchy().clone().getInducedHierarchy();
+
+    expect(inducedHierarchyGraph).toBeDefined();
+    // console.log(inducedHierarchyGraph.toStringDebugGraph());
+
+    const graphNodes = inducedHierarchyGraph.getGraphNodes();
+    const sourceNodes = inducedHierarchyGraph.getSimpleNodes();
+
+    expect(graphNodes.length).toBe(1);
+    expect(sourceNodes.length).toBe(1);
+
+    const nestedGraphNodes = graphNodes[0].getGraphNodes();
+
+    expect(nestedGraphNodes.length).toBe(1);
+
+    const defineNode = inducedHierarchyGraph.getNodeByName("Define");
+    const addNode = inducedHierarchyGraph.getNodeByName("Add");
+    const resultNode = inducedHierarchyGraph.getNodeByName("Result");
+    const nothingNode = inducedHierarchyGraph.getNodeByName("Nothing");
 
     expect(defineNode).toBeDefined();
     expect(addNode).toBeDefined();

--- a/tests/graph/IHGraph.34.demo.01.test.ts
+++ b/tests/graph/IHGraph.34.demo.01.test.ts
@@ -24,9 +24,9 @@ test("createTHGraphDemo01Create", () => {
     expect(thGraph.getNodes().length).toBe(3);
     expect(thGraph.getEdgeTypes().length).toBe(1);
     expect(thGraph.getAllEdges().length).toBe(2);
-    expect(thGraph.getNodeById("Defines")).toBe(thGraph.getNodes()[0]);
-    expect(thGraph.getNodeById("Setup")).toBe(thGraph.getNodes()[1]);
-    expect(thGraph.getNodeById("Loop")).toBe(thGraph.getNodes()[2]);
+    expect(thGraph.getNodeByName("Defines")).toBe(thGraph.getNodes()[0]);
+    expect(thGraph.getNodeByName("Setup")).toBe(thGraph.getNodes()[1]);
+    expect(thGraph.getNodeByName("Loop")).toBe(thGraph.getNodes()[2]);
     expect(thGraph.getEdgeTypeById("Sequence")).toBe(thGraph.getEdgeTypes()[0]);
     expect(thGraph.getAllEdges()[0].getSourceNode()).toBe(thGraph.getNodes()[0]);
     expect(thGraph.getAllEdges()[0].getTargetNode()).toBe(thGraph.getNodes()[1]);

--- a/tests/graph/IHGraph.34.demo.01.test.ts
+++ b/tests/graph/IHGraph.34.demo.01.test.ts
@@ -27,7 +27,7 @@ test("createTHGraphDemo01Create", () => {
     expect(thGraph.getNodeByName("Defines")).toBe(thGraph.getNodes()[0]);
     expect(thGraph.getNodeByName("Setup")).toBe(thGraph.getNodes()[1]);
     expect(thGraph.getNodeByName("Loop")).toBe(thGraph.getNodes()[2]);
-    expect(thGraph.getEdgeTypeById("Sequence")).toBe(thGraph.getEdgeTypes()[0]);
+    expect(thGraph.getEdgeTypeByName("Sequence")).toBe(thGraph.getEdgeTypes()[0]);
     expect(thGraph.getAllEdges()[0].getSourceNode()).toBe(thGraph.getNodes()[0]);
     expect(thGraph.getAllEdges()[0].getTargetNode()).toBe(thGraph.getNodes()[1]);
     expect(thGraph.getAllEdges()[0].getType()).toBe(thGraph.getEdgeTypes()[0]);


### PR DESCRIPTION
Actually, the graph used ids as names for the nodes. There is nothing wrong with having nodes with the same name, especially in different hierarchy levels. However, the name / id duality was confusing. NamedElement now clearly operates on _names_, which are not necessarily unique. If you want unique identifiers, use the hashcode of the object.